### PR TITLE
Update cluster reference paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ The config file can take 6 arguments. See provided [template](./config/template.
 |:---|:----------------|:---------|:-----|:----------------------------|
 | 1 | `dataset_id` | yes | string | dataset identifier attached to pipeline output. |
 | 2 | `output_dir` | yes | path | Absolute path to location of output. |
-| 3 | `mt_ref_genome_dir` | yes | path | Absolute path to directory containing mitochondrial ref genome and mt ref genome index files. Path: `/hot/ref/mitochondria_ref/genome_fasta`|
-| 4 | `gmapdb` | yes | path | Absolute path to to gmapdb directory. Path: `/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08` |
+| 3 | `mt_ref_genome_dir` | yes | path | Absolute path to directory containing mitochondrial ref genome and mt ref genome index files. Path: `/hot/resource/mitochondria_ref/genome_fasta`|
+| 4 | `gmapdb` | yes | path | Absolute path to to gmapdb directory. Path: `/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08` |
 | 5 | `save_intermediate_files` | no | boolean | Save intermediate files. If yes, not only the final BAM, but also the unmerged, unsorted, and duplicates unmarked BAM files will also be saved. Default is set to `false`. |
 | 6 | `cache_intermediate_pipeline_steps` | no | boolean | Enable caching to resume pipeline and the end of the last successful process completion when a pipeline fails (if true the default submission script must be modified). Default is set to `false`. |
 | 7 | `base_resource_update` | no | namespace | Namespace of parameters to update base resource allocations in the pipeline. Usage and structure are detailed in `template.config` and below. |

--- a/config/schema.yaml
+++ b/config/schema.yaml
@@ -13,13 +13,13 @@ mt_ref_genome_dir:
   mode: 'r'
   required: true
   help: 'Absolute path to directory with mtDNA reference genome'
-  default: '/hot/ref/mitochondria_ref/genome_fasta/'
+  default: '/hot/resource/mitochondria_ref/genome_fasta/'
 gmapdb:
   type: 'Path'
   mode: 'r'
   required: true
   help: 'Directory to gmapdb genomic index files'
-  default: '/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08'
+  default: '/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08'
 reference_genome_version:
   type: 'String'
   required: true

--- a/test/configtest/configtest-F16-paired-BAM.json
+++ b/test/configtest/configtest-F16-paired-BAM.json
@@ -60,11 +60,11 @@
       "cache_intermediate_pipeline_steps": false,
       "call_heteroplasmy_version": "1.0.1",
       "chrY_extraction_region": "57000000",
-      "cram_reference_genome": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "cram_reference_genome": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "dataset_id": "NFTEST",
       "date": "19970704T165655Z",
       "docker_container_registry": "ghcr.io/uclahs-cds",
-      "gmapdb": "/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
+      "gmapdb": "/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
       "heteroplasmy_script_docker_image": "ghcr.io/uclahs-cds/call-heteroplasmy-script:1.0.1",
       "input": {
         "BAM": {
@@ -108,7 +108,7 @@
       "mitoCaller2vcf_version": "1.0.0",
       "mitocaller_docker_image": "ghcr.io/uclahs-cds/mitocaller:1.0.0",
       "mitocaller_version": "1.0.0",
-      "mt_ref_genome_dir": "/hot/ref/mitochondria_ref/genome_fasta/",
+      "mt_ref_genome_dir": "/hot/resource/mitochondria_ref/genome_fasta/",
       "mtoolbox_version": "1.2.1-b52269e",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-mtSNV-VER.SI.ON/NA24143/mitoCaller-1.0.0/",

--- a/test/configtest/configtest-F32-paired-BAM.json
+++ b/test/configtest/configtest-F32-paired-BAM.json
@@ -60,11 +60,11 @@
       "cache_intermediate_pipeline_steps": false,
       "call_heteroplasmy_version": "1.0.1",
       "chrY_extraction_region": "57000000",
-      "cram_reference_genome": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "cram_reference_genome": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "dataset_id": "NFTEST",
       "date": "19970704T165655Z",
       "docker_container_registry": "ghcr.io/uclahs-cds",
-      "gmapdb": "/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
+      "gmapdb": "/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
       "heteroplasmy_script_docker_image": "ghcr.io/uclahs-cds/call-heteroplasmy-script:1.0.1",
       "input": {
         "BAM": {
@@ -108,7 +108,7 @@
       "mitoCaller2vcf_version": "1.0.0",
       "mitocaller_docker_image": "ghcr.io/uclahs-cds/mitocaller:1.0.0",
       "mitocaller_version": "1.0.0",
-      "mt_ref_genome_dir": "/hot/ref/mitochondria_ref/genome_fasta/",
+      "mt_ref_genome_dir": "/hot/resource/mitochondria_ref/genome_fasta/",
       "mtoolbox_version": "1.2.1-b52269e",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-mtSNV-VER.SI.ON/NA24143/mitoCaller-1.0.0/",

--- a/test/configtest/configtest-F72-normal-BAM.json
+++ b/test/configtest/configtest-F72-normal-BAM.json
@@ -60,11 +60,11 @@
       "cache_intermediate_pipeline_steps": false,
       "call_heteroplasmy_version": "1.0.1",
       "chrY_extraction_region": "57000000",
-      "cram_reference_genome": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "cram_reference_genome": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "dataset_id": "NFTEST",
       "date": "19970704T165655Z",
       "docker_container_registry": "ghcr.io/uclahs-cds",
-      "gmapdb": "/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
+      "gmapdb": "/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
       "heteroplasmy_script_docker_image": "ghcr.io/uclahs-cds/call-heteroplasmy-script:1.0.1",
       "input": {
         "BAM": {
@@ -99,7 +99,7 @@
       "mitoCaller2vcf_version": "1.0.0",
       "mitocaller_docker_image": "ghcr.io/uclahs-cds/mitocaller:1.0.0",
       "mitocaller_version": "1.0.0",
-      "mt_ref_genome_dir": "/hot/ref/mitochondria_ref/genome_fasta/",
+      "mt_ref_genome_dir": "/hot/resource/mitochondria_ref/genome_fasta/",
       "mtoolbox_version": "1.2.1-b52269e",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-mtSNV-VER.SI.ON/NA24149/mitoCaller-1.0.0/",

--- a/test/configtest/configtest-F72-normal-CRAM.json
+++ b/test/configtest/configtest-F72-normal-CRAM.json
@@ -60,11 +60,11 @@
       "cache_intermediate_pipeline_steps": false,
       "call_heteroplasmy_version": "1.0.1",
       "chrY_extraction_region": "57000000",
-      "cram_reference_genome": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "cram_reference_genome": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "dataset_id": "NFTEST",
       "date": "19970704T165655Z",
       "docker_container_registry": "ghcr.io/uclahs-cds",
-      "gmapdb": "/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
+      "gmapdb": "/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
       "heteroplasmy_script_docker_image": "ghcr.io/uclahs-cds/call-heteroplasmy-script:1.0.1",
       "input": {
         "CRAM": {
@@ -99,7 +99,7 @@
       "mitoCaller2vcf_version": "1.0.0",
       "mitocaller_docker_image": "ghcr.io/uclahs-cds/mitocaller:1.0.0",
       "mitocaller_version": "1.0.0",
-      "mt_ref_genome_dir": "/hot/ref/mitochondria_ref/genome_fasta/",
+      "mt_ref_genome_dir": "/hot/resource/mitochondria_ref/genome_fasta/",
       "mtoolbox_version": "1.2.1-b52269e",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-mtSNV-VER.SI.ON/NA24149/mitoCaller-1.0.0/",
@@ -182,7 +182,7 @@
       "samtools_version": "1.20",
       "save_intermediate_files": false,
       "ucla_cds": true,
-      "validate_extra_args": "-r /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "validate_extra_args": "-r /hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "validation_list": [
         "[/hot/software/pipeline/pipeline-call-mtSNV/Nextflow/development/input/data/illumina/CRAM/BWA-MEM2-2.2.1_GATK-4.2.4.1_IlluminaSampleTest_NA24149.cram",
         "index]"
@@ -327,7 +327,7 @@
         }
       },
       "withName:extract_mtDNA_SAMtools": {
-        "containerOptions": "--volume /hot/ref/reference/GRCh38-BI-20160721:/hot/ref/reference/GRCh38-BI-20160721",
+        "containerOptions": "--volume /hot/resource/reference-genome/GRCh38-BI-20160721:/hot/resource/reference-genome/GRCh38-BI-20160721",
         "cpus": "1",
         "memory": {
           "1": "8 GB",
@@ -337,7 +337,7 @@
         }
       },
       "withName:validate_input": {
-        "containerOptions": "--volume /hot/ref/reference/GRCh38-BI-20160721:/hot/ref/reference/GRCh38-BI-20160721",
+        "containerOptions": "--volume /hot/resource/reference-genome/GRCh38-BI-20160721:/hot/resource/reference-genome/GRCh38-BI-20160721",
         "cpus": "1",
         "memory": "2 GB"
       },

--- a/test/configtest/configtest-F72-paired-BAM.json
+++ b/test/configtest/configtest-F72-paired-BAM.json
@@ -60,11 +60,11 @@
       "cache_intermediate_pipeline_steps": false,
       "call_heteroplasmy_version": "1.0.1",
       "chrY_extraction_region": "57000000",
-      "cram_reference_genome": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "cram_reference_genome": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "dataset_id": "NFTEST",
       "date": "19970704T165655Z",
       "docker_container_registry": "ghcr.io/uclahs-cds",
-      "gmapdb": "/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
+      "gmapdb": "/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
       "heteroplasmy_script_docker_image": "ghcr.io/uclahs-cds/call-heteroplasmy-script:1.0.1",
       "input": {
         "BAM": {
@@ -108,7 +108,7 @@
       "mitoCaller2vcf_version": "1.0.0",
       "mitocaller_docker_image": "ghcr.io/uclahs-cds/mitocaller:1.0.0",
       "mitocaller_version": "1.0.0",
-      "mt_ref_genome_dir": "/hot/ref/mitochondria_ref/genome_fasta/",
+      "mt_ref_genome_dir": "/hot/resource/mitochondria_ref/genome_fasta/",
       "mtoolbox_version": "1.2.1-b52269e",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-mtSNV-VER.SI.ON/NA24143/mitoCaller-1.0.0/",

--- a/test/configtest/configtest-F72-paired-CRAM.json
+++ b/test/configtest/configtest-F72-paired-CRAM.json
@@ -60,11 +60,11 @@
       "cache_intermediate_pipeline_steps": false,
       "call_heteroplasmy_version": "1.0.1",
       "chrY_extraction_region": "57000000",
-      "cram_reference_genome": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "cram_reference_genome": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "dataset_id": "NFTEST",
       "date": "19970704T165655Z",
       "docker_container_registry": "ghcr.io/uclahs-cds",
-      "gmapdb": "/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
+      "gmapdb": "/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
       "heteroplasmy_script_docker_image": "ghcr.io/uclahs-cds/call-heteroplasmy-script:1.0.1",
       "input": {
         "CRAM": {
@@ -108,7 +108,7 @@
       "mitoCaller2vcf_version": "1.0.0",
       "mitocaller_docker_image": "ghcr.io/uclahs-cds/mitocaller:1.0.0",
       "mitocaller_version": "1.0.0",
-      "mt_ref_genome_dir": "/hot/ref/mitochondria_ref/genome_fasta/",
+      "mt_ref_genome_dir": "/hot/resource/mitochondria_ref/genome_fasta/",
       "mtoolbox_version": "1.2.1-b52269e",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-mtSNV-VER.SI.ON/NA24143/mitoCaller-1.0.0/",
@@ -191,7 +191,7 @@
       "samtools_version": "1.20",
       "save_intermediate_files": false,
       "ucla_cds": true,
-      "validate_extra_args": "-r /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "validate_extra_args": "-r /hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "validation_list": [
         "[/hot/software/pipeline/pipeline-call-mtSNV/Nextflow/development/input/data/illumina/CRAM/BWA-MEM2-2.2.1_GATK-4.2.4.1_IlluminaSampleTest_NA24149.cram",
         "index]",
@@ -338,7 +338,7 @@
         }
       },
       "withName:extract_mtDNA_SAMtools": {
-        "containerOptions": "--volume /hot/ref/reference/GRCh38-BI-20160721:/hot/ref/reference/GRCh38-BI-20160721",
+        "containerOptions": "--volume /hot/resource/reference-genome/GRCh38-BI-20160721:/hot/resource/reference-genome/GRCh38-BI-20160721",
         "cpus": "1",
         "memory": {
           "1": "8 GB",
@@ -348,7 +348,7 @@
         }
       },
       "withName:validate_input": {
-        "containerOptions": "--volume /hot/ref/reference/GRCh38-BI-20160721:/hot/ref/reference/GRCh38-BI-20160721",
+        "containerOptions": "--volume /hot/resource/reference-genome/GRCh38-BI-20160721:/hot/resource/reference-genome/GRCh38-BI-20160721",
         "cpus": "1",
         "memory": "2 GB"
       },

--- a/test/configtest/configtest-F72-tumor-BAM.json
+++ b/test/configtest/configtest-F72-tumor-BAM.json
@@ -60,11 +60,11 @@
       "cache_intermediate_pipeline_steps": false,
       "call_heteroplasmy_version": "1.0.1",
       "chrY_extraction_region": "57000000",
-      "cram_reference_genome": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "cram_reference_genome": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "dataset_id": "NFTEST",
       "date": "19970704T165655Z",
       "docker_container_registry": "ghcr.io/uclahs-cds",
-      "gmapdb": "/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
+      "gmapdb": "/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
       "heteroplasmy_script_docker_image": "ghcr.io/uclahs-cds/call-heteroplasmy-script:1.0.1",
       "input": {
         "BAM": {
@@ -99,7 +99,7 @@
       "mitoCaller2vcf_version": "1.0.0",
       "mitocaller_docker_image": "ghcr.io/uclahs-cds/mitocaller:1.0.0",
       "mitocaller_version": "1.0.0",
-      "mt_ref_genome_dir": "/hot/ref/mitochondria_ref/genome_fasta/",
+      "mt_ref_genome_dir": "/hot/resource/mitochondria_ref/genome_fasta/",
       "mtoolbox_version": "1.2.1-b52269e",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-mtSNV-VER.SI.ON/NA24143/mitoCaller-1.0.0/",

--- a/test/configtest/configtest-F72-tumor-CRAM.json
+++ b/test/configtest/configtest-F72-tumor-CRAM.json
@@ -60,11 +60,11 @@
       "cache_intermediate_pipeline_steps": false,
       "call_heteroplasmy_version": "1.0.1",
       "chrY_extraction_region": "57000000",
-      "cram_reference_genome": "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "cram_reference_genome": "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "dataset_id": "NFTEST",
       "date": "19970704T165655Z",
       "docker_container_registry": "ghcr.io/uclahs-cds",
-      "gmapdb": "/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
+      "gmapdb": "/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08",
       "heteroplasmy_script_docker_image": "ghcr.io/uclahs-cds/call-heteroplasmy-script:1.0.1",
       "input": {
         "CRAM": {
@@ -99,7 +99,7 @@
       "mitoCaller2vcf_version": "1.0.0",
       "mitocaller_docker_image": "ghcr.io/uclahs-cds/mitocaller:1.0.0",
       "mitocaller_version": "1.0.0",
-      "mt_ref_genome_dir": "/hot/ref/mitochondria_ref/genome_fasta/",
+      "mt_ref_genome_dir": "/hot/resource/mitochondria_ref/genome_fasta/",
       "mtoolbox_version": "1.2.1-b52269e",
       "output_dir": "/tmp/outputs",
       "output_dir_base": "/tmp/outputs/call-mtSNV-VER.SI.ON/NA24143/mitoCaller-1.0.0/",
@@ -182,7 +182,7 @@
       "samtools_version": "1.20",
       "save_intermediate_files": false,
       "ucla_cds": true,
-      "validate_extra_args": "-r /hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
+      "validate_extra_args": "-r /hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta",
       "validation_list": [
         "[/hot/software/pipeline/pipeline-call-mtSNV/Nextflow/development/input/data/illumina/CRAM/BWA-MEM2-2.2.1_GATK-4.2.4.1_IlluminaSampleTest_NA24143.cram",
         "index]"
@@ -327,7 +327,7 @@
         }
       },
       "withName:extract_mtDNA_SAMtools": {
-        "containerOptions": "--volume /hot/ref/reference/GRCh38-BI-20160721:/hot/ref/reference/GRCh38-BI-20160721",
+        "containerOptions": "--volume /hot/resource/reference-genome/GRCh38-BI-20160721:/hot/resource/reference-genome/GRCh38-BI-20160721",
         "cpus": "1",
         "memory": {
           "1": "8 GB",
@@ -337,7 +337,7 @@
         }
       },
       "withName:validate_input": {
-        "containerOptions": "--volume /hot/ref/reference/GRCh38-BI-20160721:/hot/ref/reference/GRCh38-BI-20160721",
+        "containerOptions": "--volume /hot/resource/reference-genome/GRCh38-BI-20160721:/hot/resource/reference-genome/GRCh38-BI-20160721",
         "cpus": "1",
         "memory": "2 GB"
       },

--- a/test/input.config
+++ b/test/input.config
@@ -15,13 +15,13 @@ params {
     output_dir = ''
 
     //Directory to mtDNA reference genomes
-    mt_ref_genome_dir = '/hot/ref/mitochondria_ref/genome_fasta/'
+    mt_ref_genome_dir = '/hot/resource/mitochondria_ref/genome_fasta/'
     //Directory to gmapdb genomic index files
-    gmapdb = '/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08'
+    gmapdb = '/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08'
 
     reference_genome_version = 'GRCh38'
 
-    cram_reference_genome = '/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
+    cram_reference_genome = '/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta'
     }
 
 methods.setup()


### PR DESCRIPTION
This PR updates reference paths that were renamed during the most recent cluster downtime.

I was specifically looking for single lines containing one (or more) of the following keys, so I missed any paths split across multiple lines.

| Search String                                                  |
|----------------------------------------------------------------|
| `/hot/ref/`                                                    |
| `/hot/ref/cohort/TCGA/CCG-AIM/`                                |
| `/hot/ref/cohort/TCGA/PanCanAtlas/`                            |
| `/hot/ref/database/1000Genomes/`                               |
| `/hot/ref/database/GDC-34.0 `                                  |
| `/hot/ref/database/GDC-34.0/`                                  |
| `/hot/ref/database/PCAWG/`                                     |
| `/hot/ref/database/ProstateTumor/Boutros-Yamaguchi-PRAD-CPCG/` |
| `/hot/ref/reference/`                                          |
| `/hot/resource/SMC-HET/`                                       |

A table of updated filepaths and whether or not they resolve to a file is included below. Where the original paths still exist due to symlinks I verified that they resolve to the same file as the updated path.

| Original                                                              |                    | Updated                                                                           |                    |
|-----------------------------------------------------------------------|--------------------|-----------------------------------------------------------------------------------|--------------------|
| `/hot/ref/mitochondria_ref/genome_fasta`                              | :white_check_mark: | `/hot/resource/mitochondria_ref/genome_fasta`                                     | :white_check_mark: |
| `/hot/ref/mitochondria_ref/gmapdb/gmapdb_2021-03-08`                  | :white_check_mark: | `/hot/resource/mitochondria_ref/gmapdb/gmapdb_2021-03-08`                         | :white_check_mark: |
| `/hot/ref/mitochondria_ref/genome_fasta/`                             | :white_check_mark: | `/hot/resource/mitochondria_ref/genome_fasta/`                                    | :white_check_mark: |
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` | :white_check_mark: |
| `/hot/ref/reference/GRCh38-BI-20160721`                               | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721`                               | :white_check_mark: |