### PR TITLE
Add option to skip mtDNA extraction and alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 - tumor purity option for `call_heteroplasmy` process
+- Add option to start running from call_mtSNV and skip extract_mtDNA and align_mtDNA
 ---
 ## [6.0.0-rc.1] - 2025-03-03
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The config file can take 11 arguments. See provided [template](./config/template
 | 9 | `probability_downsample` | no | float | Corresponds to the PROBABILITY parameter in DownsampleSam. Specifies the fraction of reads to retain during downsampling. |
 | 10 |`downsample_strategy`  | no | string | Corresponds to the STRATEGY parameter in DownsampleSam. Determines the algorithm used for downsampling. Options include ConstantMemory, HighAccuracy, and Chained. |
 | 11 |`downsample_accuracy`  | no | string | Corresponds to the ACCURACY parameter in DownsampleSam. Defines the desired accuracy level for the downsampling process. A smaller value indicates higher accuracy but may require more memory. |
+| 12 | `mtbam_given` | boolean | string | Set to true if you want to skip mtDNA extraction and alignment - designed to run when you have existing mtDNA BAM outputs from MToolBox and want to rerun call-heteroplasmy to retrieve purity-adjusted values. Need to replace value in BAM key in input.yaml to mtDNA BAM outputs. Default is set to `false` |
 
 Additionally, There are 3 parameters which are defined in a [default config](./config/default.config) but can be optionally included and overwritten in the `input.config`.
 

--- a/config/methods.config
+++ b/config/methods.config
@@ -63,34 +63,68 @@ methods {
         methods.set_input_type()
         params.input_channel_list = []
         params.purity = 1.0
-        params.input[params.input_type].each {
-            sample_type, sample ->
-            def entry_map = [
-                'sample_type': sample_type,
-                'sample_id': sample.sample_id,
-                'sample_data': sample.path,
-                'sample_index': methods.get_index_file(sample.path)
+
+    if (params.mtbam_given) {
+        // mtbam_given mode: convert directly to tuples
+        ['normal', 'tumor'].each { sample_type ->
+            def sample = params.input.BAM[sample_type]
+            if (sample) {
+                params.input_channel_list << [
+                    sample_type,                 // val(type)
+                    sample.sample_id,           // val(sample_name)
+                    sample.path         // path(bam)
                 ]
-            params.input_channel_list.add(entry_map)
             }
-        // set sample mode
+        }
+        // set sample_mode and purity
         switch (params.input_channel_list.size()) {
             case 0:
                 log.error "No samples provided"
                 break
             case 1:
                 params.sample_mode = 'single'
-                params.sample_id = params.input_channel_list[0].sample_id
+                params.sample_id = params.input_channel_list[0][1] // sample_id
                 break
             case 2:
                 params.sample_mode = 'paired'
-                params.sample_id = params.input_channel_list.find({ it.sample_type == 'tumor' }).sample_id
-                params.purity = params.input[params.input_type].tumor.purity
+                params.sample_id = params.input.BAM.tumor.sample_id
+                params.purity = params.input.BAM.tumor.purity
                 break
-            }
+        }
 
-        params.input_list = params.input_channel_list.collect{ tuple -> tuple.values() }
-        params.validation_list =params.input_channel_list.collect { tuple -> [tuple.sample_data, tuple.sample_index] }
+        // save as input list for nextflow channel
+        params.input_list = params.input_channel_list
+
+    }  else {
+            params.input[params.input_type].each {
+                sample_type, sample ->
+                def entry_map = [
+                    'sample_type': sample_type,
+                    'sample_id': sample.sample_id,
+                    'sample_data': sample.path,
+                    'sample_index': methods.get_index_file(sample.path)
+                    ]
+                params.input_channel_list.add(entry_map)
+                }
+            // set sample mode
+            switch (params.input_channel_list.size()) {
+                case 0:
+                    log.error "No samples provided"
+                    break
+                case 1:
+                    params.sample_mode = 'single'
+                    params.sample_id = params.input_channel_list[0].sample_id
+                    break
+                case 2:
+                    params.sample_mode = 'paired'
+                    params.sample_id = params.input_channel_list.find({ it.sample_type == 'tumor' }).sample_id
+                    params.purity = params.input[params.input_type].tumor.purity
+                    break
+                }
+
+            params.input_list = params.input_channel_list.collect{ tuple -> tuple.values() }
+            params.validation_list =params.input_channel_list.collect { tuple -> [tuple.sample_data, tuple.sample_index] }
+        }
         // create info string for log
         params.input_string = ''
         params.input[params.input_type].each {

--- a/config/template.config
+++ b/config/template.config
@@ -25,6 +25,9 @@ params {
     downsample_strategy = 'HighAccuracy' // options: ['HighAccuracy', 'ConstantMemory', 'Chained']
     downsample_accuracy = "1.0E-4"
 
+    // Do the paths given under BAM in input.yaml refer to MToolBox output BAM paths
+    // If yes, skip all steps before call_mtSNV (ie. extract_mtDNA and align_mtDNA)
+    mtbam_given = false
 
     reference_genome_version = '' // options: ['GRCh37', 'GRCh38']
     // Path to the reference FASTA used to compress the CRAM


### PR DESCRIPTION
# Description
I added an option to skip mtDNA extraction and alignment if output BAM paths from MToolBox are given instead of BAM outputs from recalibrate BAM. This can be indicated by a new parameter in the template.config called "mtbam_given" (default = FALSE). 

This was added because you have to rerun the whole mtSNV pipeline again if you want purity-adjusted heteroplasmy fraction values. If whoever outputted pipelines decided to not keep intermediate files (specifically the mitocaller .tsv outputs) the call-heteroplasmy docker cannot be run outside the pipeline to adjust for purity. Furthermore, output VCF files on its own cannot be used to return purity-adjusted heteroplasmic mtSNVs if you want to filter by minimum coverage - this is because we cannot retrieve coverage of the mtSNV site from normal VCFs if the mtSNVs are only present in tumour VCFs and absent in normal VCFs.

## Testing Results

- NFTest
  - log:    /hot/user/jieunoh/pipeline-call-mtSNV-add-option/test_dir/test_mtSNV.log
  - sample:   DTB-205-T
  - input yaml: /hot/user/jieunoh/pipeline-call-mtSNV-add-option/test_dir/input.yaml
  - config:   /hot/user/jieunoh/pipeline-call-mtSNV-add-option/test_dir/template.config
  - output:    /hot/user/jieunoh/pipeline-call-mtSNV-add-option/test_dir/output
  - submission script: /hot/user/jieunoh/pipeline-call-mtSNV-add-option/test_dir/submit.sh

# Checklist
<!-- Please read each of the following items and confirm by replacing the [ ] with a [X] -->

- [ ] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).

- [ ] I have reviewed the [Nextflow pipeline standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3193890/Nextflow+pipeline+standardization).

- [x] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD\_username (or 5 letters of AD if AD is too long)]-\[brief\_description\_of\_branch\].

- [ ] I have set up or verified the branch protection rule following the [github standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3190380/GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request.

- [x] I have added my name to the contributors listings in the ``manifest`` block in the `nextflow.config` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [x] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and `manifest` block of the `nextflow.config` file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline using NFTest, _or_ I have justified why I did not need to run NFTest above.
